### PR TITLE
feat: add browser-based Partydeck handler builder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+## Scope
+These instructions apply to the entire repository.
+
+## Guidelines
+- This project is intended for GitHub Pages and uses only client-side technologies (HTML, CSS, JavaScript).
+- Format JavaScript with two-space indentation and end statements with semicolons.
+- Keep README files and user-facing documentation in English.
+- When a `package.json` exists with tests or lint tasks, run `npm test` before committing. If no tests are available, note it in the PR description.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# Partydeck-Butler
-Automatically creates working handler files for partydeck-rs 
+# Partydeck Butler
+
+Partydeck Butler is a browser-based tool that assembles PartyDeck handler packages (`.pdh`) from public game metadata. The application runs entirely in the browser and can be hosted via GitHub Pages.
+
+## Usage
+1. Open `index.html` locally or through the repository's GitHub Pages site.
+2. Enter a game name and choose the target platform.
+3. Click **Generate** to download a `.pdh` file containing `handler.json` and a Steam icon.
+
+The tool queries Steam and PCGamingWiki for available information and applies simple heuristics for handler configuration.
+
+## Development
+This project consists only of static files. No build step is required.
+Run `npm test` if test scripts are added; currently there are no automated tests.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,119 @@
+const log = (msg) => {
+  const el = document.getElementById('log');
+  el.textContent += `${msg}\n`;
+};
+
+const slugify = (name) =>
+  name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
+async function fetchAppId(name) {
+  const url =
+    'https://cors.isomorphic-git.org/https://store.steampowered.com/api/storesearch/?term=' +
+    encodeURIComponent(name) +
+    '&l=english&cc=us';
+  const res = await fetch(url);
+  const data = await res.json();
+  return data.items && data.items.length ? data.items[0].id.toString() : null;
+}
+
+async function fetchPCGW(name) {
+  const query = encodeURIComponent(`_pageName="${name}"`);
+  const url =
+    'https://www.pcgamingwiki.com/w/api.php?action=cargoquery&tables=infobox_game&fields=_pageName,Engine&limit=1&where=' +
+    query +
+    '&format=json&origin=*';
+  const res = await fetch(url);
+  const json = await res.json();
+  if (json.cargoquery && json.cargoquery.length) {
+    return json.cargoquery[0].title;
+  }
+  return {};
+}
+
+async function fetchIcon(appId) {
+  const img = new Image();
+  img.crossOrigin = 'anonymous';
+  img.src = `https://cdn.akamai.steamstatic.com/steam/apps/${appId}/header.jpg`;
+  await img.decode();
+  const size = Math.min(img.width, img.height);
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 256;
+  const ctx = canvas.getContext('2d');
+  const sx = (img.width - size) / 2;
+  const sy = (img.height - size) / 2;
+  ctx.drawImage(img, sx, sy, size, size, 0, 0, 256, 256);
+  return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+}
+
+function buildHandler(opts) {
+  return {
+    'handler.uid': slugify(opts.name),
+    'handler.name': opts.name,
+    'handler.author': 'Partydeck Butler',
+    'handler.version': '1',
+    'handler.info': 'Generated automatically',
+    'game.symlink_dir': true,
+    'game.win': opts.platform === 'windows',
+    'game.32bit': false,
+    'game.exec': opts.exec,
+    'game.args': ['-windowed'],
+    'game.runtime': null,
+    'game.copy_instead_paths': [opts.exec],
+    'game.remove_paths': [],
+    'game.dll_overrides': {},
+    'steam.api_path': opts.steamApiPath,
+    'steam.appid': opts.appId,
+    'steam.gb_coldclient': false,
+    'profiles.unique_appdata': opts.engine === 'Unity',
+    'profiles.unique_documents': opts.engine && opts.engine.startsWith('Unreal'),
+    'profiles.unique_localshare': false,
+    'profiles.unique_config': false,
+    'profiles.game_paths': []
+  };
+}
+
+async function generate() {
+  const name = document.getElementById('game-name').value.trim();
+  if (!name) {
+    alert('Enter a game name');
+    return;
+  }
+  const platform = document.getElementById('platform').value;
+  log(`Searching Steam for "${name}"...`);
+  const appId = await fetchAppId(name);
+  if (!appId) {
+    log('AppID not found.');
+    return;
+  }
+  log(`AppID: ${appId}`);
+  const pcgw = await fetchPCGW(name);
+  const engine = pcgw.Engine || '';
+  log(`Engine: ${engine}`);
+  const opts = {
+    name,
+    platform,
+    engine,
+    appId,
+    exec: '',
+    steamApiPath:
+      engine === 'Unity'
+        ? `${name}_Data/Plugins/x86_64`
+        : engine && engine.startsWith('Unreal')
+        ? 'Engine/Binaries/ThirdParty/Steamworks/Steamv153/redistributable_bin/win64'
+        : ''
+  };
+  const handler = buildHandler(opts);
+  const zip = new JSZip();
+  zip.file('handler.json', JSON.stringify(handler, null, 2));
+  const icon = await fetchIcon(appId);
+  zip.file('icon.png', icon);
+  const blob = await zip.generateAsync({ type: 'blob' });
+  const slug = slugify(name);
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `${slug}.pdh`;
+  a.click();
+}
+
+document.getElementById('generate').addEventListener('click', generate);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Partydeck Butler</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Partydeck Butler</h1>
+  <label>
+    Game name:
+    <input id="game-name" type="text" />
+  </label>
+  <label>
+    Platform:
+    <select id="platform">
+      <option value="windows">Windows (Steam/Proton)</option>
+      <option value="linux">Linux native</option>
+    </select>
+  </label>
+  <button id="generate">Generate .pdh</button>
+  <pre id="log"></pre>
+
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+}
+label {
+  display: block;
+  margin-top: 1rem;
+}
+button {
+  margin-top: 1rem;
+}
+pre {
+  background: #eee;
+  padding: 1rem;
+  height: 150px;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- add AGENTS instructions for client-side GitHub Pages project
- implement HTML/JS/CSS PartyDeck handler builder that fetches metadata and creates .pdh archives in the browser
- update README with usage and development info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e31355bdc832a8bbc51bf4ef4517f